### PR TITLE
Ensure the two algorithms are as similar as possible 

### DIFF
--- a/GAs/DEAP_tester.py
+++ b/GAs/DEAP_tester.py
@@ -103,9 +103,10 @@ toolbox.register("evaluate", fitness_function)
         1. I use the correct crossover for the type of algorithm I am using to avoid unwanted behaviour
         2. Create copies of individuals if I want to retain the individual.
         
-    Currently using basic cxBlend as per documentation example. Will test variety.
+    Changed from cxBlend to cxOnePoint for simplicity and consistency between PyGAD implementation that currently also
+    uses single-point crossover. PyGAD does not have a cxBlend varient.
 """
-toolbox.register("mate", tools.cxBlend, alpha=0.5)  # Crossover
+toolbox.register("mate", tools.cxOnePoint)  # Crossover
 
 """
 *** From Docs: There is a variety of mutation operators in the deap.tools module. Each mutation has its own 
@@ -119,9 +120,11 @@ toolbox.register("mate", tools.cxBlend, alpha=0.5)  # Crossover
         1. I use the correct mutation for the type of algorithm I am using to avoid unwanted behaviour
         2. Create copies of individuals if I want to retain the individual.
         
-    Currently using simple Gaussian mutation as per documentation example. Will test variety.
+    Changing mutation to inversion mutation as PyGAD offers that also.
 """
-toolbox.register("mutate", tools.mutGaussian, mu=0, sigma=1.0, indpb=0.2)  # Mutation
+toolbox.register("mutate", tools.mutInversion)  # Current PyGAD implementation uses
+# Inversion mutation possible options here are: Inversion, FlipBit, UniformInt, ShuffleIndexes, ESLogNormal,
+# PolynomialBounded mutGaussian
 
 """
 *** From Docs: Selection is made among a population by the selection operators that are available in the deap.tools 
@@ -137,9 +140,9 @@ toolbox.register("mutate", tools.mutGaussian, mu=0, sigma=1.0, indpb=0.2)  # Mut
     modified. Only a reference to the individual is copied. Just like every other operator it selects and only selects.  
     ***
 
-    Using basic "select best" crossover as per documentation example. Will test variety.
+    Updated to use tournament selection, this way both DEAP and PyGAD will behave more similarly.
 """
-toolbox.register("select", tools.selBest)  # Selection
+toolbox.register("select", tools.selTournament, tournsize=3)  # Selection
 
 # Run the genetic algorithm
 def run_ga():
@@ -162,6 +165,17 @@ def run_ga():
 
     # Run the GA (using DEAP eaSimple, their basic GA option)
     # logbook is where the statistics are stored.
+
+    """
+    These are the following algorithms provided. (Note: The DEAP Team encourage users to write their own for their 
+    specific use case.):    eaSimple
+                            varOr
+                            varAnd
+                            eaMuPlusLambda
+                            eaGenerateUpdate
+                            eaMuCommaLambda
+
+    """
     population, logbook = algorithms.eaSimple(
         population,
         toolbox,

--- a/GAs/PyGAD_tester.py
+++ b/GAs/PyGAD_tester.py
@@ -23,7 +23,7 @@ def fitness_function(ga_instance, solution, solution_idx):
 
 # GA parameters
 num_generations = 50
-num_parents_mating = 20
+num_parents_mating = 15
 sol_per_pop = 100
 num_genes = X_train.shape[1]
 mutation_probability = 0.08
@@ -75,14 +75,15 @@ ga_instance = pygad.GA(
     num_genes=num_genes,
     init_range_low=-1.0,
     init_range_high=1.0,
-    mutation_percent_genes=int(mutation_probability * 100),
+    mutation_probability=mutation_probability,
     crossover_probability=0.7,
-    mutation_type="random", # Current DEAP implementation uses Gaussian mutation. Possible options here are: random,
+    mutation_type="inversion", # Current DEAP implementation uses Inversion mutation. Possible options here are: random,
     # swap, inversion, scramble and adaptive.
     crossover_type="single_point", # Current DEAP implementation uses cxBlend. Possible options here are: single-point,
     # two-points, uniform and scattered.
-    parent_selection_type="sss", # steady-state selection. Most equivalent to DEAP's selBest.
-    keep_parents=1, # simpler than DEAP, you must handle keeping parents manually in DEAP. Must ensure that is the case.
+    parent_selection_type="tournament", # Changed to tournament as this way I can better control the behaviour of both
+    # libraries
+    K_tournament=3,
     on_generation=on_generation,
 )
 


### PR DESCRIPTION
These change ensure that the algorithms in the two scripts: PyGAD_tester and DEAP_tester operate as similar as possible without writing a custom GA loop. 

This may be necessary later down the line as pygads.GA() has functionality such as controlling number of parents mating that appears impossible to emulate exactly with DEAPs out-of-the-box algorithms: 
                            eaSimple
                            varOr
                            varAnd
                            eaMuPlusLambda
                            eaGenerateUpdate
                            eaMuCommaLambda